### PR TITLE
[Name Cast]: Don't attempt to store computed columns to the database

### DIFF
--- a/src/Casts/NameCast.php
+++ b/src/Casts/NameCast.php
@@ -18,7 +18,9 @@ class NameCast implements CastsAttributes
 
     public function get($model, string $key, $value, array $attributes): Name
     {
-        if ($value) {
+        // We're probably dealing with a single column instead of a combination
+        // of two columns.
+        if (Arr::has($attributes, $key)) {
             return Name::from($value);
         }
 
@@ -28,8 +30,17 @@ class NameCast implements CastsAttributes
         return Name::from("{$firstName} {$lastName}");
     }
 
-    public function set($model, string $key, $value, array $attributes): string
+    public function set($model, string $key, $value, array $attributes): array
     {
-        return (string) $value;
+        // We're probably dealing with a single column instead of a combination
+        // of two columns.
+        if (! $value instanceof Name) {
+            return [$key => $value];
+        }
+
+        return [
+            $this->firstName => $value->first,
+            $this->lastName => $value->last,
+        ];
     }
 }

--- a/tests/Feature/NameCastTest.php
+++ b/tests/Feature/NameCastTest.php
@@ -12,7 +12,9 @@ it('casts to a name', function () {
         ->and($model->name->first)->toBe('John')
         ->and($model->name->last)->toBe('Smith')
         ->and($model->name->full)->toBe('John Smith')
-        ->and((string) $model->name)->toBe('John Smith');
+        ->and((string) $model->name)->toBe('John Smith')
+        ->and($model->getDirty())->toHaveKey('name')
+        ->and($model->getDirty()['name'])->toBe('John Smith');
 });
 
 it('can be casted from first and last name on a model', function () {
@@ -29,4 +31,14 @@ test('different first and last name attributes can be used', function () {
     expect($model->custom_name->full)->toBe('John Smith')
         ->and($model->custom_name->first)->toBe('John')
         ->and($model->custom_name->last)->toBe('Smith');
+});
+
+it('will not attempt to store a computed column to the database if it is accessed before saving the model', function () {
+    $model = new Model(['given_name' => 'John', 'family_name' => 'Smith']);
+
+    $model->custom_name;
+
+    expect($model->getDirty())->not->toHaveKey('custom_name')
+        ->toHaveKey('given_name')
+        ->toHaveKey('family_name');
 });


### PR DESCRIPTION
This PR fixes an issue where if you have a computed `name` column that is derived from a `first_name` and `last_name` column from your database table and you access the computed `name` column on the model before calling a save method on the model, Laravel will attempt to write the computed column into the database on the create/update operation. Now the NameCast will properly serialize the attributes back onto the model before persisting the model to the database, and the computed column will not be attempted to be saved as part of the query.
